### PR TITLE
fix Persian text rendering for Linux distributions

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,7 +3,6 @@ import tkinter as tk
 from tkinter import ttk
 from tkinter import messagebox
 from tkinter import filedialog
-from tkinter import Text
 from models import *
 from bidi.algorithm import get_display
 import edu


### PR DESCRIPTION
The rendering problem for Persian text is fixed by using the Arabic text reshape. This will only affects the Linux systems because the windows and mac look fine. 

note: installation of bidi is necessary. 
use `pip install python-bidi` for installation 